### PR TITLE
Fix Python version formatting in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR fixes the Python version formatting in the GitHub Actions workflow.

The issue was that GitHub Actions was interpreting '3.10' as the floating-point number '3.1' instead of Python version 3.10. This caused the CI pipeline to fail with an error that the Python version 3.1 was not found.

This PR fixes the issue by adding quotes around the Python version numbers to ensure they're treated as version strings rather than floating-point numbers.

This is a common issue with YAML parsing of version numbers that look like floating-point numbers.