### PR TITLE
Add pytest-asyncio support for integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov black flake8 mypy
+          pip install pytest pytest-cov pytest-asyncio black flake8 mypy
           pip install -e .
           
       - name: Check code formatting with Black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,14 @@ dependencies = [
 monitoring = [
     "langfuse>=2.0.0",
 ]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-asyncio>=0.21.0",
+    "black>=23.0.0",
+    "flake8>=6.0.0",
+    "mypy>=1.0.0",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/ddkang1/smart-agent"

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,5 @@ markers =
     integration: Integration tests
     functional: Functional tests
     slow: Tests that take a long time to run
+    asyncio: Mark tests as asyncio tests
 addopts = --strict-markers

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -10,7 +10,7 @@ pip install -e .
 
 # Install development dependencies
 echo "Installing development dependencies..."
-pip install pytest pytest-cov black flake8 mypy
+pip install pytest pytest-cov pytest-asyncio black flake8 mypy
 
 # Display success message
 echo "Development environment setup complete!"


### PR DESCRIPTION
This PR adds proper support for pytest-asyncio to fix the integration tests.

Key changes:
1. **Register the asyncio marker in pytest.ini**:
   - Added the asyncio marker to the list of registered markers
   - This fixes the 'asyncio not found in  configuration option' error

2. **Add pytest-asyncio as a dependency**:
   - Added to GitHub Actions workflow
   - Added to setup_dev.sh script
   - Created a new 'dev' optional dependencies group in pyproject.toml

This change aligns with the Smart Agent's unified approach to tool launching and testing by ensuring that asynchronous tests can run properly in the CI/CD pipeline.