### PR TITLE
Fix: Update tests to match current CLI and tool configuration

### DIFF
--- a/tests/functional/test_smart_agent_e2e.py
+++ b/tests/functional/test_smart_agent_e2e.py
@@ -49,7 +49,7 @@ class TestSmartAgentE2E:
         with patch("smart_agent.cli.ConfigManager", return_value=mock_config_manager):
             with patch("sys.exit"):
                 # Call start with all=True to start all services
-                start.callback(config=None, tools=True, proxy=True, all=True)
+                start.callback(config=None, tools=True, proxy=True, all=True, foreground=False)
 
         # Verify that launch_tools and launch_litellm_proxy were called
         assert mock_launch_tools.called
@@ -76,7 +76,7 @@ class TestSmartAgentE2E:
 
         # Test stopping services
         with patch("subprocess.run") as mock_run:
-            stop.callback(config=None, tools=True, proxy=True, all=True)
+            stop.callback(config=None, tools=True, proxy=True, all=True, background=False)
 
             # Verify subprocess.run was called to stop services
             assert mock_run.called

--- a/tests/integration/test_tool_management.py
+++ b/tests/integration/test_tool_management.py
@@ -35,8 +35,7 @@ class TestToolManagement:
                 "name": "Search Tool",
                 "url": "http://localhost:8001/sse",
                 "enabled": True,
-                "type": "stdio",
-                "launch_cmd": "npx",
+                "type": "uvx",
                 "repository": "search-tool",
             }
         }
@@ -48,8 +47,7 @@ class TestToolManagement:
                     "name": "Search Tool",
                     "url": "http://localhost:8001/sse",
                     "enabled": True,
-                    "type": "stdio",
-                    "launch_cmd": "npx",
+                    "type": "uvx",
                     "repository": "search-tool",
                 }
             }
@@ -66,8 +64,7 @@ class TestToolManagement:
             "name": "Search Tool",
             "url": "http://localhost:8001/sse",
             "enabled": True,
-            "type": "stdio",
-            "launch_cmd": "npx",
+            "type": "uvx",
             "repository": "search-tool",
         }
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,7 +34,7 @@ class TestCliCommands:
             # We need to patch sys.exit to prevent the test from exiting
             with patch("sys.exit"):
                 # We're testing the functionality, not the Click command itself
-                start.callback(config=None, tools=True, proxy=True, all=True)
+                start.callback(config=None, tools=True, proxy=True, all=True, foreground=False)
                 # Verify that launch_tools was called
                 assert mock_launch_tools.called
                 # Verify that launch_litellm_proxy was called
@@ -47,7 +47,7 @@ class TestCliCommands:
         from smart_agent.cli import stop
 
         # Call the internal functionality directly
-        stop.callback(config=None, tools=True, proxy=True, all=True)
+        stop.callback(config=None, tools=True, proxy=True, all=True, background=False)
 
         # Verify subprocess.run was called to stop services
         assert mock_run.called
@@ -99,8 +99,7 @@ class TestCliCommands:
                 "name": "Search Tool",
                 "url": "http://localhost:8001/sse",
                 "enabled": True,
-                "type": "stdio",
-                "launch_cmd": "npx",
+                "type": "uvx",
                 "repository": "search-tool",
             }
         }
@@ -112,8 +111,7 @@ class TestCliCommands:
                     "name": "Search Tool",
                     "url": "http://localhost:8001/sse",
                     "enabled": True,
-                    "type": "stdio",
-                    "launch_cmd": "npx",
+                    "type": "uvx",
                     "repository": "search-tool",
                 }
             }
@@ -127,8 +125,7 @@ class TestCliCommands:
             "name": "Search Tool",
             "url": "http://localhost:8001/sse",
             "enabled": True,
-            "type": "stdio",
-            "launch_cmd": "npx",
+            "type": "uvx",
             "repository": "search-tool",
         }
 


### PR DESCRIPTION
This PR updates the tests to match the current CLI implementation and tool configuration system:

1. Fixed CLI command tests:
   - Added missing 'foreground' parameter to start command tests
   - Added missing 'background' parameter to stop command tests

2. Updated tool configuration in tests:
   - Replaced 'stdio' type with 'uvx' to match the unified approach to tool launching
   - Removed outdated 'launch_cmd' property from mock configurations
   - Updated all mock tool configurations to use the current schema

These changes align the tests with the YAML-based configuration system for managing tools and the updated CLI interface implemented in previous PRs.